### PR TITLE
Updated CMS to work with SDC

### DIFF
--- a/cms/migrations/0002_auto_20140816_1918.py
+++ b/cms/migrations/0002_auto_20140816_1918.py
@@ -25,7 +25,7 @@ class Migration(migrations.Migration):
             name='PageUser',
             fields=[
                 (user_ptr_name, models.OneToOneField(primary_key=True, to=settings.AUTH_USER_MODEL, auto_created=True, parent_link=True, serialize=False, on_delete=models.CASCADE)),
-                ('created_by', models.ForeignKey(to=settings.AUTH_USER_MODEL, related_name='created_users', on_delete=models.CASCADE)),
+                ('page_user_created_by', models.ForeignKey(to=settings.AUTH_USER_MODEL, related_name='created_page_users', on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'User (page)',

--- a/cms/models/permissionmodels.py
+++ b/cms/models/permissionmodels.py
@@ -258,10 +258,10 @@ class PageUserManager(UserManager):
     use_in_migrations = False
 
 
-class PageUser(User):
+class PageUser(models.Model):
     """Cms specific user data, required for permission system
     """
-    created_by = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="created_users")
+    page_user_created_by = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="created_page_users")
 
     objects = PageUserManager()
 


### PR DESCRIPTION
Initial changes to DjangoCMS release 3.4.x so it will work with SDC Django version 1.9. 

Updated their PageUser model to be a OneToOne relationship rather than a ForeignKey, changed the `created_by` field to `page_user_created_by`. Changed their migration to correspond to the Model change
